### PR TITLE
Adds skipHeader and skipFooter methods

### DIFF
--- a/src/Concerns/CanSkipFooter.php
+++ b/src/Concerns/CanSkipFooter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Konnco\FilamentImport\Concerns;
+
+trait CanSkipFooter
+{
+    protected int $skipFooterCount = 0;
+
+    public function skipFooter(int $skipFooterCount = 1): static
+    {
+        $this->skipFooterCount = $skipFooterCount;
+
+        return $this;
+    }
+
+    public function shouldSkipFooter(): bool
+    {
+        return $this->skipFooterCount > 0;
+    }
+
+    public function getSkipFooterCount(): int
+    {
+        return $this->skipFooterCount;
+    }
+}

--- a/src/Concerns/CanSkipHeader.php
+++ b/src/Concerns/CanSkipHeader.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Konnco\FilamentImport\Concerns;
+
+trait CanSkipHeader
+{
+    protected bool $shouldSkipHeader = true;
+
+    public function skipHeader(bool $condition = true): static
+    {
+        $this->shouldSkipHeader = $condition;
+
+        return $this;
+    }
+
+    public function shouldSkipHeader(): bool
+    {
+        return $this->shouldSkipHeader;
+    }
+}

--- a/src/Import.php
+++ b/src/Import.php
@@ -34,8 +34,6 @@ class Import
 
     protected bool $shouldSkipHeader = false;
 
-    protected bool $shouldSkipFooter = false;
-
     protected int $skipFooterCount = 0;
 
     protected bool $shouldMassCreate = true;
@@ -92,13 +90,6 @@ class Import
         return $this;
     }
 
-    public function skipFooter(bool $shouldSkipFooter): static
-    {
-        $this->shouldSkipFooter = $shouldSkipFooter;
-
-        return $this;
-    }
-
     public function skipFooterCount(int $skipFooterCount = 0): static
     {
         $this->skipFooterCount = $skipFooterCount;
@@ -126,7 +117,7 @@ class Import
             ->first()
             ->skip((int) $this->shouldSkipHeader);
 
-        if ($this->shouldSkipFooter) {
+        if ($this->skipFooterCount) {
             $data = $data->slice(0, $this->skipFooterCount * -1);
         }
 


### PR DESCRIPTION
## Proposed changes
Adds skipHeader and skipFooter methods to the Import action allowing them to be set in the action themselves. Helpful for setting defaults for certain imports. Also hides these options until the file is loaded. 
